### PR TITLE
Allow WordPress coding standard spacing rules.

### DIFF
--- a/tasks/version.js
+++ b/tasks/version.js
@@ -23,8 +23,8 @@ module.exports = function(grunt) {
     var hashJs = md5(options.js);
 
     // Update scripts.php to reference the new versions
-    var regexCss = new RegExp("(wp_enqueue_style\\('" + options.cssHandle + "',(\\s*[^,]+,){2})\\s*[^\\)]+\\);");
-    var regexJs = new RegExp("(wp_register_script\\('" + options.jsHandle + "',(\\s*[^,]+,){2})\\s*[^,]+,\\s*([^\\)]+)\\);");
+    var regexCss = new RegExp("(wp_enqueue_style\\(\\s?'" + options.cssHandle + "',(\\s*[^,]+,){2})\\s*[^\\)]+\\s?\\);");
+    var regexJs = new RegExp("(wp_register_script\\(\\s?'" + options.jsHandle + "',(\\s*[^,]+,){2})\\s*[^,]+,\\s*([^\\)]+)\\s?\\);");
 
     var content = grunt.file.read(scriptsPhp);
     content = content.replace(regexCss, "$1 '" + hashCss + "');");


### PR DESCRIPTION
When you use space after opening paranthesis and before closing parantheis, grunt-wp-version won't recognize the css or js enqueue patterns.
Example:  
    wp_enqueue_style( 'soi_main', get_template_directory_uri() . '/assets/css/main.min.css', false, 'ba7fc9da018edbd7b9f34232ff3790a3' );

A small change to the regular expressions is necessary to improve this behaviour.
